### PR TITLE
CodeDeployから実行時に、wrapperを使わないように修正しました。

### DIFF
--- a/scripts/install_server
+++ b/scripts/install_server
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cd /var/javecs/calc
-./gradlew build -x test
+gradle build -x test
 
 cp -f build/libs/calc-0.0.1-SNAPSHOT.jar /var/javecs/javecs-calc
 chown ec2-user:ec2-user /var/javecs/javecs-calc


### PR DESCRIPTION
- gradlewのCLASSPATH設定が`compileKotlin`タスク実行時に影響を与えているようです。

```
CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
```